### PR TITLE
Using wmi

### DIFF
--- a/_beacons/win_notify.py
+++ b/_beacons/win_notify.py
@@ -174,10 +174,10 @@ def beacon(config):
                 if config[path].get('exclude', False):
                     for exclude in config[path]['exclude']:
                         if '*' in exclude:
-                            for wildcard_item in glob.iglob(item):
-                                _remove_acl(wildcard_item)
+                            for wildcard_exclude in glob.iglob(exclude):
+                                _remove_acl(wildcard_exclude)
                         else:
-                            _remove_acl(item)
+                            _remove_acl(exclude)
 
     #Read in events since last call.  Time_frame in minutes
     ret = _pull_events(config['win_notify_interval'])

--- a/_beacons/win_notify.py
+++ b/_beacons/win_notify.py
@@ -12,7 +12,7 @@ import datetime
 import fnmatch
 import logging
 import os
-from pprint import pprint
+import glob
 
 import salt.ext.six
 
@@ -111,7 +111,7 @@ def beacon(config):
             recurse: True
             exclude:
               - /path/to/file/or/dir/exclude1
-              - /path/to/file/or/dir/exclude2
+              - /path/to/*/file/or/dir/*/exclude2
 
     The mask list can contain the following events (the default mask is create, delete, and modify):
 
@@ -173,6 +173,9 @@ def beacon(config):
                     sys_check = 1
                 if config[path].get('exclude', False):
                     for item in config[path]['exclude']:
+                        if '*' in exclude:
+                            for wildcard_item in glob.iglob(item):
+                                _remove_acl(wildcard_item)
                         _remove_acl(item)
 
     #Read in events since last call.  Time_frame in minutes

--- a/_beacons/win_notify.py
+++ b/_beacons/win_notify.py
@@ -172,11 +172,12 @@ def beacon(config):
                     confirm = _add_acl(path, mask, wtype, recurse)
                     sys_check = 1
                 if config[path].get('exclude', False):
-                    for item in config[path]['exclude']:
+                    for exclude in config[path]['exclude']:
                         if '*' in exclude:
                             for wildcard_item in glob.iglob(item):
                                 _remove_acl(wildcard_item)
-                        _remove_acl(item)
+                        else:
+                            _remove_acl(item)
 
     #Read in events since last call.  Time_frame in minutes
     ret = _pull_events(config['win_notify_interval'])

--- a/_beacons/win_notify.py
+++ b/_beacons/win_notify.py
@@ -17,7 +17,8 @@ from pprint import pprint
 import salt.ext.six
 
 LOG = logging.getLogger(__name__)
-DEFAULT_MASK = ['Write', 'Delete', 'DeleteSubdirectoriesAndFiles', 'ChangePermissions', 'TakeOwnership'] #ExecuteFile Is really chatty
+DEFAULT_MASK = ['ExecuteFile', 'Write', 'Delete', 'DeleteSubdirectoriesAndFiles', 'ChangePermissions', 
+                'TakeOwnership'] #ExecuteFile Is really chatty
 DEFAULT_TYPE = 'all'
 
 __virtualname__ = 'win_notify'
@@ -171,7 +172,8 @@ def beacon(config):
                     confirm = _add_acl(path, mask, wtype, recurse)
                     sys_check = 1
                 if config[path].get('exclude', False):
-                    _remove_acl(path)
+                    for item in config[path]['exclude']:
+                        _remove_acl(item)
 
     #Read in events since last call.  Time_frame in minutes
     ret = _pull_events(config['win_notify_interval'])

--- a/pulsar/win_notify/pillar/beacons.sls
+++ b/pulsar/win_notify/pillar/beacons.sls
@@ -1,9 +1,9 @@
 beacons:
   win_notify:
     C:\Users: {}
-    C:\Windows:
-      exclude:
-        - C:\Windows\System32
+    C:\Windows: {}
+    #  exclude:
+    #    - C:\Windows\System32
     C:\temp: {}
 
     win_notify_interval: 30 # MUST be the same as interval

--- a/pulsar/win_notify/pillar/beacons.sls
+++ b/pulsar/win_notify/pillar/beacons.sls
@@ -1,9 +1,15 @@
 beacons:
   win_notify:
     C:\Users: {}
-    C:\Windows: {}
-    #  exclude:
-    #    - C:\Windows\System32
+    C:\Windows:
+      mask:
+        - Write
+        - Delete
+        - DeleteSubdirectoriesAndFiles
+        - ChangePermissions
+        - TakeOwnership
+      exclude:
+        - C:\Windows\System32
     C:\temp: {}
 
     win_notify_interval: 30 # MUST be the same as interval

--- a/pulsar/win_notify/pillar/beacons.sls
+++ b/pulsar/win_notify/pillar/beacons.sls
@@ -1,6 +1,10 @@
 beacons:
   win_notify:
-    C:/Users: {}
+    C:\Users: {}
+    C:\Windows: {}
+      exclude:
+        - C:\Windows\System32
+    C:\temp: {}
 
     win_notify_interval: 30  # MUST be the same as interval
     interval: 30  # MUST be the same as win_notify_interval

--- a/pulsar/win_notify/pillar/beacons.sls
+++ b/pulsar/win_notify/pillar/beacons.sls
@@ -1,11 +1,11 @@
 beacons:
   win_notify:
     C:\Users: {}
-    C:\Windows: {}
+    C:\Windows:
       exclude:
         - C:\Windows\System32
     C:\temp: {}
 
-    win_notify_interval: 30  # MUST be the same as interval
-    interval: 30  # MUST be the same as win_notify_interval
+    win_notify_interval: 30 # MUST be the same as interval
+    interval: 30 # MUST be the same as win_notify_interval
       


### PR DESCRIPTION
This changes how the  beacon configures the folders for auditing.  Before it used powershell command set-acl which does not work on c:\Users and most importantly c:\windows.  I instead had to use WMI, which does not have that restriction.  With that I also found i need to change the remove ACE function to use WMI as well, since you also cannot remove ACEs from c:\windows using native powershell commands.
I also fixed many bugs. Most notably the bug that was using the parent path of the exclude instead of the exclude path.  Example: auditing c:\windows but excluding c:\windows\system32, would actually remove the ACEs from c:\windows, instead of the system32 folder.  Other minor bug fixes as well
