### PR TITLE
Avoid "cannot watch" errors by checking if the path exists

### DIFF
--- a/_beacons/pulsar.py
+++ b/_beacons/pulsar.py
@@ -289,7 +289,7 @@ def beacon(config):
                         update = True
                     if update:
                         wm.update_watch(wd, mask=mask, rec=rec, auto_add=auto_add)
-        else:
+        elif os.path.exists(path):
             wm.add_watch(path, mask, rec=rec, auto_add=auto_add)
 
     if __salt__['config.get']('hubblestack:pulsar:maintenance', False):


### PR DESCRIPTION
@mew1033 This should fix those pyinotify logs
