### PR TITLE
Remove fileserver operations from pulsar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,9 +175,16 @@ Pulsar to be flexible.
 
     # pillar.example
     beacons:
-       pulsar:
-         paths:
-           - salt://hubblestack_pulsar_config.yaml
+      pulsar:
+        paths:
+          - /var/cache/salt/minion/files/base/hubblestack_pulsar_config.yaml
+    schedule:
+      cache_nebula:
+        function: cp.cache_file
+        seconds: 86400
+        args:
+          - salt://hubblestack_pulsar_config.yaml
+        return_job: False
 
 
     # hubblestack_pulsar_config.yaml

--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,13 @@
 beacons:
   pulsar:
     paths:
-      - salt://hubblestack_pulsar_config.yaml
+      - /var/cache/salt/minion/files/base/hubblestack_pulsar_config.yaml
     disable_during_state_run: True
+
+schedule:
+  cache_nebula:
+    function: cp.cache_file
+    seconds: 86400
+    args:
+      - salt://hubblestack_pulsar_config.yaml
+    return_job: False


### PR DESCRIPTION
There's a yet-unfiled bug in salt where fileserver operations in a
beacon can cause scheduled jobs which have fileserver operations
to hang.
