### PR TITLE
Switch to threading from multiprocessing for pulsar hang prevention

### DIFF
--- a/_beacons/pulsar.py
+++ b/_beacons/pulsar.py
@@ -15,7 +15,7 @@ Watch files and translate the changes into salt events
 from __future__ import absolute_import
 import collections
 import fnmatch
-import multiprocessing
+import threading
 import os
 import re
 import yaml
@@ -354,7 +354,7 @@ def beacon(config):
                 for item in ret:
                     transformed.append({'return': item})
                 if config.get('multiprocessing_return', True):
-                    p = multiprocessing.Process(target=__returners__[returner], args=(transformed,))
+                    p = threading.Thread(target=__returners__[returner], args=(transformed,))
                     p.daemon = True
                     p.start()
                 else:
@@ -362,7 +362,7 @@ def beacon(config):
             else:
                 for item in ret:
                     if config.get('multiprocessing_return', True):
-                        p = multiprocessing.Process(target=__returners__[returner], args=({'return': item},))
+                        p = threading.Thread(target=__returners__[returner], args=({'return': item},))
                         p.daemon = True
                         p.start()
                     else:

--- a/_beacons/win_pulsar.py
+++ b/_beacons/win_pulsar.py
@@ -11,7 +11,7 @@ import collections
 import datetime
 import fnmatch
 import logging
-import multiprocessing
+import threading
 import os
 import glob
 import yaml
@@ -199,16 +199,16 @@ def beacon(config):
                 transformed = []
                 for item in ret:
                     transformed.append({'return': item})
-                if config.get('multiprocessing_return', False):
-                    p = multiprocessing.Process(target=_return, args=((transformed,), returner))
+                if config.get('multiprocessing_return', True):
+                    p = threading.Thread(target=_return, args=((transformed,), returner))
                     p.daemon = True
                     p.start()
                 else:
                     __returners__[returner](transformed)
             else:
                 for item in ret:
-                    if config.get('multiprocessing_return', False):
-                        p = multiprocessing.Process(target=_return, args=(({'return': item},), returner))
+                    if config.get('multiprocessing_return', True):
+                        p = threading.Thread(target=_return, args=(({'return': item},), returner))
                         p.daemon = True
                         p.start()
                     else:


### PR DESCRIPTION
Early indications are that the threads are not leaking memory, which is good! This solution also works on windows, where multiprocessing was not working (likely due to salt loader magic).

Threading should be OK because these are not CPU-bound tasks, just I/O-bound.
